### PR TITLE
Bump Editor and package version

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -11,7 +11,7 @@
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.5",
-    "com.unity.visualscripting": "1.8.0",
+    "com.unity.visualscripting": "1.9.1",
     "com.unity.xr.arfoundation": "5.1.0-pre.10",
     "com.unity.xr.hands": "1.3.0",
     "com.unity.xr.interaction.toolkit": "2.5.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.burst": {
-      "version": "1.8.7",
+      "version": "1.8.8",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -59,7 +59,7 @@
       "source": "builtin",
       "dependencies": {
         "com.unity.xr.oculus": "4.0.0",
-        "com.unity.xr.openxr": "1.8.1"
+        "com.unity.xr.openxr": "1.8.2"
       }
     },
     "com.unity.ide.rider": {
@@ -226,7 +226,7 @@
       }
     },
     "com.unity.visualscripting": {
-      "version": "1.8.0",
+      "version": "1.9.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.5f1
-m_EditorVersionWithRevision: 2022.3.5f1 (9674261d40ee)
+m_EditorVersion: 2022.3.8f1
+m_EditorVersionWithRevision: 2022.3.8f1 (b5eafc012955)


### PR DESCRIPTION
Bump version to .8f1 and visual scripting to 1.9.1 to avoid auto upgrade to 1.9.0 with a breaking change with the version of Unity on the demo machines.